### PR TITLE
Fix camera topic remapping issue

### DIFF
--- a/turtlebot3_autorace_camera/launch/extrinsic_camera_calibration.launch.py
+++ b/turtlebot3_autorace_camera/launch/extrinsic_camera_calibration.launch.py
@@ -57,8 +57,8 @@ def generate_launch_description():
             {'is_extrinsic_camera_calibration_mode': calibration_mode}
         ],
         remappings=[
-            ('/camera/image_input', '/camera/image_rect_color'),
-            ('/camera/image_input/compressed', '/camera/image_rect_color/compressed'),
+            ('/camera/image_input', '/camera/image_raw'),
+            ('/camera/image_input/compressed', '/camera/image_raw/compressed'),
             ('/camera/image_output', '/camera/image_projected'),
             ('/camera/image_output/compressed', '/camera/image_projected/compressed'),
             ('/camera/image_calib', '/camera/image_extrinsic_calib'),


### PR DESCRIPTION
Fixed an issue with camera topics remapping incorrectly. Fixed an issue where nodes were not working because they were not connected.

Issues https://github.com/ROBOTIS-GIT/turtlebot3_autorace/issues/62